### PR TITLE
fix(tests): navigation reveals answers in exam mode

### DIFF
--- a/libs/react/containers/src/tests/test-question-navigation/test-question-navigation.tsx
+++ b/libs/react/containers/src/tests/test-question-navigation/test-question-navigation.tsx
@@ -28,7 +28,9 @@ export const TestQuestionNavigation: FunctionComponent<
     <>
       <QuestionNavigation
         sx={{ width: "100%" }}
-        status="in-progress-with-results"
+        status={
+          test.mode === "exam" ? "in-progress" : "in-progress-with-results"
+        }
         pageSize={80}
         currentId={question.questionId}
         questions={test.questions.map((q) => ({


### PR DESCRIPTION
**Before**
![grafik](https://github.com/PupoSDC/chair-flight/assets/50082450/5eb44d72-23e6-4389-a01b-c383125ed51a)

**After**
![grafik](https://github.com/PupoSDC/chair-flight/assets/50082450/1da8f0b5-c634-4c0c-ad09-e666e2e3c870)
