### PR TITLE
chore: fix pokes to keep app alive

### DIFF
--- a/libs/content/question-bank-737/vite.config.ts
+++ b/libs/content/question-bank-737/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     globals: true,
     include: ["**/*.{test,spec}.{ts,tsx}"],
     cache: {
-      dir: "../../node_modules/.vitest",
+      dir: "../../../node_modules/.vitest",
     },
     coverage: {
       all: true,

--- a/vercel.json
+++ b/vercel.json
@@ -4,12 +4,24 @@
   "rewrites": [],
   "crons": [
     {
-      "path": "/api/trpc/questionBankAtpl.searchQuestions?batch=1&input=%7B%220%22%3A%7B%22q%22%3A%221%22%2C%22limit%22%3A12%2C%22cursor%22%3A0%7D%7D",
+      "path": "/api/trpc/questionBankAtpl.searchQuestions?input=%7B\"json\"%3A%7B\"q\"%3A\"p\"%2C\"limit\"%3A12%2C\"cursor\"%3A0%7D%7D",
       "schedule": "*/2 * * * *"
     },
     {
-      "path": "/api/trpc/question737.searchQuestions?batch=1&input=%7B%220%22%3A%7B%22q%22%3A%221%22%2C%22limit%22%3A12%2C%22cursor%22%3A0%7D%7D",
+      "path": "/api/trpc/questionBank737.searchQuestions?input=%7B\"json\"%3A%7B\"q\"%3A\"p\"%2C\"limit\"%3A12%2C\"cursor\"%3A0%7D%7D",
       "schedule": "*/2 * * * *"
+    },
+    {
+      "path": "/",
+      "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/modules/atpl/tests/create",
+      "schedule": "*/10 * * * *"
+    },
+    {
+      "path": "/modules/737/tests/create",
+      "schedule": "*/10 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Some of these were using wrong urls meaning that the cold start of the application was too slow.
Added a few more pokes to the most obviously visited routes.