### PR TITLE
feat: add Learning objectives tree

### DIFF
--- a/apps/next-app/pages/modules/[questionBank]/learning-objectives/[learningObjectiveId]/index.page.tsx
+++ b/apps/next-app/pages/modules/[questionBank]/learning-objectives/[learningObjectiveId]/index.page.tsx
@@ -1,9 +1,11 @@
-import { Link, Sheet } from "@mui/joy";
+import { default as LinkIcon } from "@mui/icons-material/ChevronRightOutlined";
+import { Divider, Link, Sheet, Stack, Typography } from "@mui/joy";
 import { AppHead } from "@chair-flight/react/components";
 import {
   LayoutModule,
   LearningObjectiveOverview,
   LearningObjectiveQuestions,
+  LearningObjectiveTree,
 } from "@chair-flight/react/containers";
 import { ssrHandler } from "@chair-flight/trpc/server";
 import type { QuestionBankName } from "@chair-flight/base/types";
@@ -20,11 +22,16 @@ type PageProps = {
   learningObjectiveId: string;
 };
 
+const BIG_SCREEN =
+  "@media screen and (min-height: 520px) and (min-width: 600px)";
+
 export const Page: NextPage<PageProps> = ({
   questionBank,
   learningObjectiveId,
 }) => {
   const loLink = `/modules/${questionBank}/learning-objectives`;
+  const treeLink = `${loLink}/${learningObjectiveId}/tree`;
+  const questionsLink = `${loLink}/${learningObjectiveId}/questions`;
   const crumbs = [
     [questionBank.toUpperCase(), `/modules/${questionBank}`],
     ["Learning Objectives", loLink],
@@ -39,31 +46,48 @@ export const Page: NextPage<PageProps> = ({
         questionBank={questionBank}
         learningObjectiveId={learningObjectiveId}
       />
-      <LearningObjectiveQuestions
-        questionBank={questionBank}
-        learningObjectiveId={learningObjectiveId}
+      <Stack
+        direction="row"
         sx={{
           flex: 1,
-          overflowY: "scroll",
+          overflow: "hidden",
           display: "none",
-
-          "@media screen and (min-height: 520px) and (min-width: 600px)": {
-            display: "block",
-          },
-        }}
-      />
-      <Sheet
-        sx={{
-          p: 2,
-
-          "@media screen and (min-height: 520px) and (min-width: 600px)": {
-            display: "none",
-          },
+          [BIG_SCREEN]: { display: "flex" },
         }}
       >
-        <Link href={`${loLink}/${learningObjectiveId}/questions`}>
-          Questions
-        </Link>
+        <Stack sx={{ width: "50%", mr: 1, height: "100%" }}>
+          <Link href={treeLink}>
+            <Typography level="h3" sx={{ verticalAlign: "middle" }}>
+              Related Learning Objectives
+              <LinkIcon sx={{ verticalAlign: "middle" }} color="primary" />
+            </Typography>
+          </Link>
+          <LearningObjectiveTree
+            forceMode="mobile"
+            questionBank={questionBank}
+            learningObjectiveId={learningObjectiveId}
+            sx={{ overflowY: "scroll", flex: 1 }}
+          />
+        </Stack>
+        <Stack sx={{ width: "50%", ml: 1, height: "100%" }}>
+          <Link href={questionsLink}>
+            <Typography level="h3" sx={{ verticalAlign: "middle" }}>
+              Questions
+              <LinkIcon sx={{ verticalAlign: "middle" }} color="primary" />
+            </Typography>
+          </Link>
+          <LearningObjectiveQuestions
+            forceMode="mobile"
+            questionBank={questionBank}
+            learningObjectiveId={learningObjectiveId}
+            sx={{ overflowY: "scroll", flex: 1 }}
+          />
+        </Stack>
+      </Stack>
+      <Sheet sx={{ [BIG_SCREEN]: { display: "none" }, p: 1 }}>
+        <Link href={treeLink}>Related Learning Objectives</Link>
+        <Divider sx={{ my: 1 }} />
+        <Link href={questionsLink}>Questions</Link>
       </Sheet>
     </LayoutModule>
   );
@@ -74,6 +98,7 @@ export const getServerSideProps = ssrHandler<PageProps, PageParams>(
     await Promise.all([
       LayoutModule.getData({ params, helper }),
       LearningObjectiveOverview.getData({ params, helper }),
+      LearningObjectiveTree.getData({ params, helper }),
       LearningObjectiveQuestions.getData({ params, helper }),
     ]);
     return { props: params };

--- a/apps/next-app/pages/modules/[questionBank]/learning-objectives/[learningObjectiveId]/tree.page.tsx
+++ b/apps/next-app/pages/modules/[questionBank]/learning-objectives/[learningObjectiveId]/tree.page.tsx
@@ -1,0 +1,55 @@
+import { AppHead } from "@chair-flight/react/components";
+import {
+  LayoutModule,
+  LearningObjectiveTree,
+} from "@chair-flight/react/containers";
+import { ssrHandler } from "@chair-flight/trpc/server";
+import type { QuestionBankName } from "@chair-flight/base/types";
+import type { Breadcrumbs } from "@chair-flight/react/containers";
+import type { NextPage } from "next";
+
+type PageParams = {
+  questionBank: QuestionBankName;
+  learningObjectiveId: string;
+};
+
+type PageProps = {
+  questionBank: QuestionBankName;
+  learningObjectiveId: string;
+};
+
+export const Page: NextPage<PageProps> = ({
+  questionBank,
+  learningObjectiveId,
+}) => {
+  const loLink = `/modules/${questionBank}/learning-objectives`;
+  const crumbs = [
+    [questionBank.toUpperCase(), `/modules/${questionBank}`],
+    ["Learning Objectives", `${loLink}`],
+    [learningObjectiveId, `${loLink}/${learningObjectiveId}`],
+    "Related Learning Objectives",
+  ] as Breadcrumbs;
+
+  return (
+    <LayoutModule fixedHeight questionBank={questionBank} breadcrumbs={crumbs}>
+      <AppHead />
+      <LearningObjectiveTree
+        questionBank={questionBank}
+        learningObjectiveId={learningObjectiveId}
+        sx={{ flex: 1, overflowY: "scroll" }}
+      />
+    </LayoutModule>
+  );
+};
+
+export const getServerSideProps = ssrHandler<PageProps, PageParams>(
+  async ({ helper, params }) => {
+    await Promise.all([
+      LayoutModule.getData({ params, helper }),
+      LearningObjectiveTree.getData({ params, helper }),
+    ]);
+    return { props: params };
+  },
+);
+
+export default Page;

--- a/libs/base/utils/src/index.ts
+++ b/libs/base/utils/src/index.ts
@@ -1,12 +1,13 @@
-export const makeMap = <T>(
+export const makeMap = <T, V = T>(
   array: T[],
   getId: (t: T) => string,
-): Record<string, T> => {
+  getContent: (t: T) => V = (t) => t as unknown as V,
+): Record<string, V> => {
   return array.reduce(
     (sum, v) => {
-      sum[getId(v)] = v;
+      sum[getId(v)] = getContent(v);
       return sum;
     },
-    {} as Record<string, T>,
+    {} as Record<string, V>,
   );
 };

--- a/libs/react/components/src/index.ts
+++ b/libs/react/components/src/index.ts
@@ -16,6 +16,7 @@ export * from "./hooks/use-media-query";
 export * from "./hooks/use-window-resize";
 export * from "./image-viewer/image-viewer";
 export * from "./input-slider";
+export * from "./learning-objectives-list";
 export * from "./markdown-client";
 export * from "./module-selection-button";
 export * from "./nested-checkbox-select";

--- a/libs/react/components/src/learning-objectives-list/index.ts
+++ b/libs/react/components/src/learning-objectives-list/index.ts
@@ -1,0 +1,2 @@
+export { LearningObjectiveList } from "./learning-objective-list";
+export type { LearningObjectiveListProps } from "./learning-objective-list";

--- a/libs/react/components/src/learning-objectives-list/learning-objective-list.stories.tsx
+++ b/libs/react/components/src/learning-objectives-list/learning-objective-list.stories.tsx
@@ -1,0 +1,72 @@
+import { LearningObjectiveList } from "./learning-objective-list";
+import type { Meta, StoryObj } from "@storybook/react";
+
+type Story = StoryObj<typeof LearningObjectiveList>;
+
+export const Playground: Story = {};
+
+const meta: Meta<typeof LearningObjectiveList> = {
+  title: "Components/LearningObjectiveList",
+  component: LearningObjectiveList,
+  tags: ["autodocs"],
+  args: {
+    loading: false,
+    error: false,
+    forceMode: undefined,
+    items: [
+      {
+        id: "010.01",
+        href: "/modules/atpl/learning-objectives/010.01",
+
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "International Law:\n-  Conventions, Agreements And Organisations",
+        source: "",
+        numberOfQuestions: 190,
+      },
+      {
+        id: "010.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01",
+
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "The Convention on International Civil Aviation (Chicago) - Icao Doc 7300/9 - Convention on the High Seas (Geneva, 29 April 1958)",
+        source: "",
+        numberOfQuestions: 103,
+      },
+      {
+        id: "010.01.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01.01",
+
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "The establishment of the Convention on International Civil Aviation, Chicago, 7 December 1944",
+        source: "",
+        numberOfQuestions: 13,
+      },
+      {
+        id: "010.01.01.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01.01.01",
+
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "Explain the circumstances that led to the establishment of the Convention on International Civil Aviation, Chicago, 7 December 1944.",
+        source: "ICAO Doc 7300/9 Preamble",
+        numberOfQuestions: 13,
+      },
+    ],
+    sx: {
+      height: "500px",
+      overflow: "hidden",
+    },
+    courseMap: {
+      all: "All Courses",
+      ATPL_A: "ATPL(A)",
+      CPL_A: "CPL(A)",
+      ATPL_H_IR: "ATPL(H) IR",
+      ATPL_H_VFR: "ATPL(H) VFR",
+      CPL_H: "CPL(H)",
+      IR: "IR",
+      CBIR_A: "CBIR(A)",
+    },
+  },
+  argTypes: {},
+};
+
+export default meta;

--- a/libs/react/components/src/learning-objectives-list/learning-objective-list.tsx
+++ b/libs/react/components/src/learning-objectives-list/learning-objective-list.tsx
@@ -1,0 +1,147 @@
+import { forwardRef } from "react";
+import {
+  Box,
+  Chip,
+  Divider,
+  Link,
+  ListItemContent,
+  Typography,
+} from "@mui/joy";
+import { MarkdownClientCompressed } from "../markdown-client";
+import { SearchList } from "../search-list";
+import type { SearchListProps } from "../search-list";
+
+export type LearningObjectiveListItem = {
+  id: string;
+  text: string;
+  source: string;
+  href: string;
+  numberOfQuestions: number;
+  courses: string[];
+};
+
+export type LearningObjectiveListProps = Omit<
+  SearchListProps<LearningObjectiveListItem>,
+  | "items"
+  | "renderThead"
+  | "renderTableRow"
+  | "renderListItemContent"
+  | "errorMessage"
+  | "noDataMessage"
+> & {
+  currentCourse?: string;
+  courseMap?: Record<string, string>;
+  items?: SearchListProps<LearningObjectiveListItem>["items"];
+};
+
+export const LearningObjectiveList = forwardRef<
+  HTMLDivElement,
+  LearningObjectiveListProps
+>(
+  (
+    { items = [], currentCourse = "all", courseMap = {}, ...otherProps },
+    ref,
+  ) => {
+    return (
+      <SearchList
+        {...otherProps}
+        ref={ref}
+        items={items}
+        errorMessage={"Error fetching Learning Objectives"}
+        noDataMessage={"No Learning Objectives found"}
+        renderThead={() => (
+          <thead>
+            <tr>
+              <th style={{ width: "8em" }}>LO</th>
+              <th>Description</th>
+              <th style={{ width: "14em" }}>Source</th>
+              <th style={{ width: "14em" }}>Courses</th>
+              <th style={{ width: "7em" }}>Questions</th>
+            </tr>
+          </thead>
+        )}
+        renderTableRow={(result) => (
+          <tr key={result.id}>
+            <td>
+              <Link href={result.href}>
+                <Typography>{result.id}</Typography>
+              </Link>
+            </td>
+            <td>
+              <MarkdownClientCompressed>{result.text}</MarkdownClientCompressed>
+            </td>
+            <Box component={"td"} fontSize={"xs"}>
+              <MarkdownClientCompressed>
+                {result.source}
+              </MarkdownClientCompressed>
+            </Box>
+            <td>
+              {result.courses
+                .filter((c) => {
+                  if (currentCourse === "all") return true;
+                  if (c === currentCourse) return true;
+                  return false;
+                })
+                .map((c) => (
+                  <Chip key={c} size="sm" sx={{ m: 0.5 }}>
+                    {courseMap[c]}
+                  </Chip>
+                ))}
+            </td>
+            <Box
+              component={"td"}
+              children={result.numberOfQuestions}
+              sx={{
+                textAlign: "right",
+                pr: `2em !important`,
+              }}
+            />
+          </tr>
+        )}
+        renderListItemContent={(result) => (
+          <ListItemContent>
+            <Link href={`/modules/atpl/learning-objectives/${result.id}`}>
+              <Typography>{result.id}</Typography>
+            </Link>
+            <Typography level="body-xs" sx={{ fontSize: 10 }}>
+              {result.courses.map((c) => courseMap[c]).join(", ")}
+            </Typography>
+            <Typography level="body-xs" sx={{ fontSize: 10 }}>
+              Number of Questions {result.numberOfQuestions}
+            </Typography>
+            <Box
+              sx={{
+                mt: 1,
+                fontSize: "sm",
+                height: "7em",
+                overflow: "hidden",
+                maskImage:
+                  "linear-gradient(to bottom, black 50%, transparent 100%)",
+              }}
+            >
+              <MarkdownClientCompressed>{result.text}</MarkdownClientCompressed>
+              {result.source && (
+                <>
+                  <Divider sx={{ width: "50%", my: 0.5 }} />
+                  <Typography level="body-xs">source: </Typography>
+                  <Box
+                    sx={{
+                      color: "text.tertiary",
+                      fontSize: "xs",
+                    }}
+                  >
+                    <MarkdownClientCompressed>
+                      {result.source}
+                    </MarkdownClientCompressed>
+                  </Box>
+                </>
+              )}
+            </Box>
+          </ListItemContent>
+        )}
+      />
+    );
+  },
+);
+
+LearningObjectiveList.displayName = "LearningObjectiveList";

--- a/libs/react/containers/src/index.ts
+++ b/libs/react/containers/src/index.ts
@@ -4,6 +4,7 @@ export * from "./flashcards/flashcard-list";
 export * from "./flashcards/flashcard-test";
 export * from "./layouts/layout-module";
 export * from "./layouts/layout-public";
+export * from "./learning-objectives/learning-objective-tree";
 export * from "./learning-objectives/learning-objective-overview";
 export * from "./learning-objectives/learning-objective-questions";
 export * from "./learning-objectives/learning-objectives-search";

--- a/libs/react/containers/src/learning-objectives/learning-objective-questions/learning-objective-questions.tsx
+++ b/libs/react/containers/src/learning-objectives/learning-objective-questions/learning-objective-questions.tsx
@@ -18,7 +18,13 @@ const useSearchQuestions =
     .useInfiniteQuery;
 
 export const LearningObjectiveQuestions = container<Props>(
-  ({ questionBank, learningObjectiveId, sx, component = "section" }) => {
+  ({
+    forceMode,
+    questionBank,
+    learningObjectiveId,
+    sx,
+    component = "section",
+  }) => {
     const { data, isLoading, isError, fetchNextPage } = useSearchQuestions(
       {
         questionBank,
@@ -33,6 +39,7 @@ export const LearningObjectiveQuestions = container<Props>(
 
     return (
       <QuestionList
+        forceMode={forceMode}
         loading={isLoading}
         error={isError}
         items={(data?.pages ?? []).flatMap((p) => p.items)}

--- a/libs/react/containers/src/learning-objectives/learning-objective-tree/index.ts
+++ b/libs/react/containers/src/learning-objectives/learning-objective-tree/index.ts
@@ -1,0 +1,1 @@
+export { LearningObjectiveTree } from "./learning-objective-tree";

--- a/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.stories.tsx
+++ b/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.stories.tsx
@@ -1,0 +1,40 @@
+import {
+  questionBankLoSearchGetSearchConfig,
+  questionBankLoSearchSearchLearningObjectivesMock,
+  trpcMsw,
+} from "@chair-flight/trpc/mock";
+import { LearningObjectiveTree } from "./learning-objective-tree";
+import type { Meta, StoryObj } from "@storybook/react";
+
+type Story = StoryObj<typeof LearningObjectiveTree>;
+
+export const Playground: Story = {};
+
+const meta: Meta<typeof LearningObjectiveTree> = {
+  title: "Containers/LearningObjectives/LearningObjectiveTree",
+  component: LearningObjectiveTree,
+  tags: ["autodocs"],
+  args: {
+    questionBank: "atpl",
+    learningObjectiveId: "010",
+    forceMode: undefined,
+    sx: {
+      height: "500px",
+      overflow: "hidden",
+    },
+  },
+  parameters: {
+    msw: {
+      handlers: [
+        trpcMsw.questionBankLoSearch.getLearningObjectiveTree.query(
+          () => questionBankLoSearchSearchLearningObjectivesMock,
+        ),
+        trpcMsw.questionBankLoSearch.getSearchConfigFilters.query(
+          () => questionBankLoSearchGetSearchConfig,
+        ),
+      ],
+    },
+  },
+};
+
+export default meta;

--- a/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.tsx
+++ b/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.tsx
@@ -1,16 +1,13 @@
+import { makeMap } from "@chair-flight/base/utils";
+import { LearningObjectiveList } from "@chair-flight/react/components";
+import { trpc } from "@chair-flight/trpc/client";
+import { container, getRequiredParam } from "../../wraper";
 import type {
   LearningObjectiveId,
   QuestionBankName,
 } from "@chair-flight/base/types";
-import { makeMap } from "@chair-flight/base/utils";
-import type {
-  LearningObjectiveListProps} from "@chair-flight/react/components";
-import {
-  LearningObjectiveList
-} from "@chair-flight/react/components";
-import { trpc } from "@chair-flight/trpc/client";
+import type { LearningObjectiveListProps } from "@chair-flight/react/components";
 import type { AppRouterOutput } from "@chair-flight/trpc/server";
-import { container, getRequiredParam } from "../../wraper";
 
 type Props = {
   forceMode?: LearningObjectiveListProps["forceMode"];

--- a/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.tsx
+++ b/libs/react/containers/src/learning-objectives/learning-objective-tree/learning-objective-tree.tsx
@@ -1,0 +1,77 @@
+import type {
+  LearningObjectiveId,
+  QuestionBankName,
+} from "@chair-flight/base/types";
+import { makeMap } from "@chair-flight/base/utils";
+import type {
+  LearningObjectiveListProps} from "@chair-flight/react/components";
+import {
+  LearningObjectiveList
+} from "@chair-flight/react/components";
+import { trpc } from "@chair-flight/trpc/client";
+import type { AppRouterOutput } from "@chair-flight/trpc/server";
+import { container, getRequiredParam } from "../../wraper";
+
+type Props = {
+  forceMode?: LearningObjectiveListProps["forceMode"];
+  questionBank: QuestionBankName;
+  learningObjectiveId: LearningObjectiveId;
+};
+
+type Params = {
+  questionBank: QuestionBankName;
+  learningObjectiveId: LearningObjectiveId;
+};
+
+type Data =
+  AppRouterOutput["questionBankLoSearch"]["getLearningObjectiveTree"] &
+    AppRouterOutput["questionBankLoSearch"]["getSearchConfigFilters"];
+
+export const LearningObjectiveTree = container<Props, Params, Data>(
+  ({ sx, forceMode, component = "section", ...params }) => {
+    const { items, courses } = LearningObjectiveTree.useData(params);
+    return (
+      <LearningObjectiveList
+        forceMode={forceMode}
+        component={component}
+        sx={sx}
+        items={items}
+        courseMap={makeMap(
+          courses,
+          (c) => c.id,
+          (t) => t.text,
+        )}
+      />
+    );
+  },
+);
+
+LearningObjectiveTree.displayName = "LearningObjectiveTree";
+
+LearningObjectiveTree.getData = async ({ helper, params }) => {
+  const router = helper.questionBankLoSearch;
+  const questionBank = getRequiredParam(params, "questionBank");
+  const learningObjectiveId = getRequiredParam(params, "learningObjectiveId");
+  const [data1, data2] = await Promise.all([
+    router.getLearningObjectiveTree.fetch({
+      questionBank,
+      learningObjectiveId,
+    }),
+    router.getSearchConfigFilters.fetch({ questionBank }),
+  ]);
+  return { ...data1, ...data2 };
+};
+
+LearningObjectiveTree.useData = (params) => {
+  const router = trpc.questionBankLoSearch;
+  const questionBank = getRequiredParam(params, "questionBank");
+  const learningObjectiveId = getRequiredParam(params, "learningObjectiveId");
+  const data1 = router.getLearningObjectiveTree.useSuspenseQuery({
+    questionBank,
+    learningObjectiveId,
+  })[0];
+  const data2 = router.getSearchConfigFilters.useSuspenseQuery({
+    questionBank,
+  })[0];
+  return { ...data1, ...data2 };
+};

--- a/libs/react/containers/src/learning-objectives/learning-objectives-search/learning-objectives-search.tsx
+++ b/libs/react/containers/src/learning-objectives/learning-objectives-search/learning-objectives-search.tsx
@@ -1,26 +1,15 @@
 import { useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Box,
-  Link,
-  ListItemContent,
-  Select,
-  Option,
-  Stack,
-  Typography,
-  Chip,
-  Divider,
-} from "@mui/joy";
+import { Select, Option, Stack } from "@mui/joy";
 import { z } from "zod";
 import { makeMap } from "@chair-flight/base/utils";
 import {
   SearchQuery,
   HookFormSelect,
-  MarkdownClientCompressed,
   SearchFilters,
   SearchHeader,
-  SearchList,
+  LearningObjectiveList,
 } from "@chair-flight/react/components";
 import { trpc } from "@chair-flight/trpc/client";
 import { createUsePersistenceHook } from "../../hooks/use-persistence";
@@ -78,8 +67,6 @@ export const LearningObjectivesSearch = container<Props, Params, Data>(
       Number(subject !== "all") +
       Number(course !== "all");
 
-    const coursesMap = makeMap(courses, (c) => c.id);
-
     return (
       <Stack component={component} sx={sx}>
         <SearchHeader>
@@ -128,106 +115,18 @@ export const LearningObjectivesSearch = container<Props, Params, Data>(
           />
         </SearchHeader>
 
-        <SearchList
+        <LearningObjectiveList
           loading={isLoading}
           error={isError}
+          currentCourse={course}
+          courseMap={makeMap(
+            courses,
+            (c) => c.id,
+            (t) => t.text,
+          )}
           items={(data?.pages ?? []).flatMap((p) => p.items)}
           onFetchNextPage={fetchNextPage}
           sx={{ flex: 1, overflow: "hidden" }}
-          renderThead={() => (
-            <thead>
-              <tr>
-                <th style={{ width: "8em" }}>LO</th>
-                <th>Description</th>
-                <th style={{ width: "14em" }}>Source</th>
-                <th style={{ width: "14em" }}>Courses</th>
-                <th style={{ width: "7em" }}>Questions</th>
-              </tr>
-            </thead>
-          )}
-          renderTableRow={(result) => (
-            <tr key={result.id}>
-              <td>
-                <Link href={result.href}>
-                  <Typography>{result.id}</Typography>
-                </Link>
-              </td>
-              <td>
-                <MarkdownClientCompressed>
-                  {result.text}
-                </MarkdownClientCompressed>
-              </td>
-              <Box component={"td"} fontSize={"xs"}>
-                <MarkdownClientCompressed>
-                  {result.source}
-                </MarkdownClientCompressed>
-              </Box>
-              <td>
-                {result.courses
-                  .filter((c) => {
-                    if (course === "all") return true;
-                    if (c === course) return true;
-                    return false;
-                  })
-                  .map((course) => (
-                    <Chip key={course} size="sm" sx={{ m: 0.5 }}>
-                      {coursesMap[course].text}
-                    </Chip>
-                  ))}
-              </td>
-              <Box
-                component={"td"}
-                children={result.numberOfQuestions}
-                sx={{
-                  textAlign: "right",
-                  pr: `2em !important`,
-                }}
-              />
-            </tr>
-          )}
-          renderListItemContent={(result) => (
-            <ListItemContent>
-              <Link href={`/modules/atpl/learning-objectives/${result.id}`}>
-                <Typography>{result.id}</Typography>
-              </Link>
-              <Typography level="body-xs" sx={{ fontSize: 10 }}>
-                {result.courses.map((c) => coursesMap[c]).join(", ")}
-              </Typography>
-              <Typography level="body-xs" sx={{ fontSize: 10 }}>
-                Number of Questions {result.numberOfQuestions}
-              </Typography>
-              <Box
-                sx={{
-                  mt: 1,
-                  fontSize: "sm",
-                  height: "7em",
-                  overflow: "hidden",
-                  maskImage:
-                    "linear-gradient(to bottom, black 50%, transparent 100%)",
-                }}
-              >
-                <MarkdownClientCompressed>
-                  {result.text}
-                </MarkdownClientCompressed>
-                {result.source && (
-                  <>
-                    <Divider sx={{ width: "50%", my: 0.5 }} />
-                    <Typography level="body-xs">source: </Typography>
-                    <Box
-                      sx={{
-                        color: "text.tertiary",
-                        fontSize: "xs",
-                      }}
-                    >
-                      <MarkdownClientCompressed>
-                        {result.source}
-                      </MarkdownClientCompressed>
-                    </Box>
-                  </>
-                )}
-              </Box>
-            </ListItemContent>
-          )}
         />
       </Stack>
     );

--- a/libs/trpc/mock/src/__mocks__/question-bank-lo-search-get-learning-objective-tree.mock.ts
+++ b/libs/trpc/mock/src/__mocks__/question-bank-lo-search-get-learning-objective-tree.mock.ts
@@ -1,0 +1,51 @@
+import type { AppRouterOutput } from "@chair-flight/trpc/server";
+
+export const questionBankLoSearchGetLearningObjectiveTree: AppRouterOutput["questionBankLoSearch"]["getLearningObjectiveTree"] =
+  {
+    items: [
+      {
+        id: "010.01",
+        href: "/modules/atpl/learning-objectives/010.01",
+        parentId: "010",
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "International Law:\n-  Conventions, Agreements And Organisations",
+        source: "",
+        questionBank: "atpl",
+        subject: "010",
+        numberOfQuestions: 190,
+      },
+      {
+        id: "010.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01",
+        parentId: "010.01",
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "The Convention on International Civil Aviation (Chicago) - Icao Doc 7300/9 - Convention on the High Seas (Geneva, 29 April 1958)",
+        source: "",
+        questionBank: "atpl",
+        subject: "010",
+        numberOfQuestions: 103,
+      },
+      {
+        id: "010.01.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01.01",
+        parentId: "010.01.01",
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "The establishment of the Convention on International Civil Aviation, Chicago, 7 December 1944",
+        source: "",
+        questionBank: "atpl",
+        subject: "010",
+        numberOfQuestions: 13,
+      },
+      {
+        id: "010.01.01.01.01",
+        href: "/modules/atpl/learning-objectives/010.01.01.01.01",
+        parentId: "010.01.01.01",
+        courses: ["ATPL_A", "CPL_A", "ATPL_H_IR", "ATPL_H_VFR", "CPL_H"],
+        text: "Explain the circumstances that led to the establishment of the Convention on International Civil Aviation, Chicago, 7 December 1944.",
+        source: "ICAO Doc 7300/9 Preamble",
+        questionBank: "atpl",
+        subject: "010",
+        numberOfQuestions: 13,
+      },
+    ],
+  };

--- a/libs/trpc/mock/src/index.ts
+++ b/libs/trpc/mock/src/index.ts
@@ -13,6 +13,7 @@ export * from "./__mocks__/flashcards.mock";
 export * from "./__mocks__/question-bank-annex-search-get-search-config-filters.mock";
 export * from "./__mocks__/question-bank-annex-search-search-annexes.mock";
 export * from "./__mocks__/question-bank-lo-search-get-search-config.mock";
+export * from "./__mocks__/question-bank-lo-search-get-learning-objective-tree.mock";
 export * from "./__mocks__/question-bank-lo-search-search-learning-objectives.mock";
 export * from "./__mocks__/question-bank-question-search-get-questions-from-learning-objectives.mock";
 export * from "./__mocks__/question-bank-question-search-get-search-config-filters.mock";


### PR DESCRIPTION
- Adds new container "Learning Objective tree" that resuses existing UI to show all learning objectives below a given LO, as well as its parents. 

Closes https://github.com/PupoSDC/chair-flight/issues/82