### PR TITLE
fix(search): filters for docs and LO search

### DIFF
--- a/libs/core/app/src/search/doc-search.ts
+++ b/libs/core/app/src/search/doc-search.ts
@@ -110,11 +110,7 @@ export const searchDocs = async ({
 }) => {
   const opts: SearchOptions = {
     fuzzy: 0.2,
-    fields: ps.searchField
-      ? ps.searchField === "all"
-        ? undefined
-        : [ps.searchField]
-      : undefined,
+    fields: ps.searchField === "all" ? undefined : [ps.searchField],
   };
 
   const results = ps.q

--- a/libs/core/app/src/search/doc-search.ts
+++ b/libs/core/app/src/search/doc-search.ts
@@ -110,7 +110,11 @@ export const searchDocs = async ({
 }) => {
   const opts: SearchOptions = {
     fuzzy: 0.2,
-    fields: ps.searchField === "all" ? [ps.searchField] : undefined,
+    fields: ps.searchField
+      ? ps.searchField === "all"
+        ? undefined
+        : [ps.searchField]
+      : undefined,
   };
 
   const results = ps.q

--- a/libs/core/app/src/search/learning-objective-search.ts
+++ b/libs/core/app/src/search/learning-objective-search.ts
@@ -125,11 +125,7 @@ export const searchLearningObjectives = async ({
 }) => {
   const opts: SearchOptions = {
     fuzzy: 0.2,
-    fields: ps.searchField
-      ? ps.searchField === "all"
-        ? undefined
-        : [ps.searchField]
-      : undefined,
+    fields: ps.searchField === "all" ? undefined : [ps.searchField],
   };
 
   const results =

--- a/libs/core/app/src/search/learning-objective-search.ts
+++ b/libs/core/app/src/search/learning-objective-search.ts
@@ -125,6 +125,11 @@ export const searchLearningObjectives = async ({
 }) => {
   const opts: SearchOptions = {
     fuzzy: 0.2,
+    fields: ps.searchField
+      ? ps.searchField === "all"
+        ? undefined
+        : [ps.searchField]
+      : undefined,
   };
 
   const results =

--- a/libs/core/app/src/search/question-search.ts
+++ b/libs/core/app/src/search/question-search.ts
@@ -142,11 +142,7 @@ export const searchQuestions = async ({
 }) => {
   const opts: SearchOptions = {
     fuzzy: 0.2,
-    fields: ps.searchField
-      ? ps.searchField === "all"
-        ? undefined
-        : [ps.searchField]
-      : undefined,
+    fields: ps.searchField === "all" ? undefined : [ps.searchField],
   };
 
   const results = ps.q


### PR DESCRIPTION
fixes #118 (again) for docs search and LO search
LO search previously didn't take field filters into account at all